### PR TITLE
WIP: hide `No data` column in histograms

### DIFF
--- a/python-histograms/tests/unit/test_histograms.py
+++ b/python-histograms/tests/unit/test_histograms.py
@@ -3,7 +3,7 @@ import mock
 import json
 import numpy as np
 from . import fixtures as fx
-from histograms import main, compute_categories, UserError, aggregate_histograms, _align_categories
+from histograms import main, compute_categories, UserError, aggregate_histograms, _align_categories, INCLUDE_NO_DATA
 
 
 def get_output_real(add_null=True):
@@ -108,7 +108,7 @@ def test_main_real(mock_save_results, mock_get_results, mock_fetch_data):
     main()
 
     js = json.loads(mock_save_results.call_args[0][0])
-    assert js == get_output_real()
+    assert js == get_output_real(add_null=False)
 
 
 OUTPUT_NOMINAL = [
@@ -177,70 +177,76 @@ def test_main_nominal(mock_save_results, mock_get_results, mock_fetch_data):
     assert js == OUTPUT_NOMINAL
 
 
-OUTPUT_AGGREGATE = [
-    {
-        'chart': {
-            'type': 'column'
-        },
-        'label': 'Histogram',
-        'title': {
-            'text': 'Score test 1 histogram'
-        },
-        'xAxis': {
-            'categories': [
-                '700.00 - 730.00', '730.00 - 760.00', '760.00 - 790.00', '790.00 - 820.00', '820.00 - 850.00',
-                '850.00 - 880.00', '880.00 - 910.00', '910.00 - 940.00', '940.00 - 970.00', '970.00 - 1000.00',
-                '1000.00 - 1030.00', '1030.00 - 1060.00', '1060.00 - 1090.00', '1090.00 - 1120.00', '1120.00 - 1150.00',
-                '1150.00 - 1180.00', '1180.00 - 1210.00', '1210.00 - 1240.00', '1240.00 - 1270.00', '1270.00 - 1300.00',
-                'No data'
-            ]
-        },
-        'yAxis': {
-            'allowDecimals': False,
-            'min': 0,
+def get_output_aggregate(add_null=True):
+    out = [
+        {
+            'chart': {
+                'type': 'column'
+            },
+            'label': 'Histogram',
             'title': {
-                'text': 'Number of participants'
-            }
-        },
-        'series': [{
-            'name': 'all',
-            'data': [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 0, 0, 2, 2, 0, 2, 0, 1]
-        }]
-    }, {
-        'chart': {
-            'type': 'column'
-        },
-        'label': 'Histogram - Age Group',
-        'title': {
-            'text': 'Score test 1 histogram by Age Group'
-        },
-        'xAxis': {
-            'categories': [
-                '700.00 - 730.00', '730.00 - 760.00', '760.00 - 790.00', '790.00 - 820.00', '820.00 - 850.00',
-                '850.00 - 880.00', '880.00 - 910.00', '910.00 - 940.00', '940.00 - 970.00', '970.00 - 1000.00',
-                '1000.00 - 1030.00', '1030.00 - 1060.00', '1060.00 - 1090.00', '1090.00 - 1120.00', '1120.00 - 1150.00',
-                '1150.00 - 1180.00', '1180.00 - 1210.00', '1210.00 - 1240.00', '1240.00 - 1270.00', '1270.00 - 1300.00',
-                'No data'
-            ]
-        },
-        'yAxis': {
-            'allowDecimals': False,
-            'min': 0,
+                'text': 'Score test 1 histogram'
+            },
+            'xAxis': {
+                'categories': [
+                    '700.00 - 730.00', '730.00 - 760.00', '760.00 - 790.00', '790.00 - 820.00', '820.00 - 850.00',
+                    '850.00 - 880.00', '880.00 - 910.00', '910.00 - 940.00', '940.00 - 970.00', '970.00 - 1000.00',
+                    '1000.00 - 1030.00', '1030.00 - 1060.00', '1060.00 - 1090.00', '1090.00 - 1120.00', '1120.00 - 1150.00',
+                    '1150.00 - 1180.00', '1180.00 - 1210.00', '1210.00 - 1240.00', '1240.00 - 1270.00', '1270.00 - 1300.00'
+                ]
+            },
+            'yAxis': {
+                'allowDecimals': False,
+                'min': 0,
+                'title': {
+                    'text': 'Number of participants'
+                }
+            },
+            'series': [{
+                'name': 'all',
+                'data': [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 0, 0, 2, 2, 0, 2, 0]
+            }]
+        }, {
+            'chart': {
+                'type': 'column'
+            },
+            'label': 'Histogram - Age Group',
             'title': {
-                'text': 'Number of participants'
-            }
-        },
-        'series': [
-            {
-                'name': '-50y',
-                'data': [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 2, 0, 0, 0, 0, 1]
-            }, {
-                'name': '50-59y',
-                'data': [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 2, 0, 2, 0, 0]
-            }
-        ]
-    }
-]
+                'text': 'Score test 1 histogram by Age Group'
+            },
+            'xAxis': {
+                'categories': [
+                    '700.00 - 730.00', '730.00 - 760.00', '760.00 - 790.00', '790.00 - 820.00', '820.00 - 850.00',
+                    '850.00 - 880.00', '880.00 - 910.00', '910.00 - 940.00', '940.00 - 970.00', '970.00 - 1000.00',
+                    '1000.00 - 1030.00', '1030.00 - 1060.00', '1060.00 - 1090.00', '1090.00 - 1120.00', '1120.00 - 1150.00',
+                    '1150.00 - 1180.00', '1180.00 - 1210.00', '1210.00 - 1240.00', '1240.00 - 1270.00', '1270.00 - 1300.00'
+                ]
+            },
+            'yAxis': {
+                'allowDecimals': False,
+                'min': 0,
+                'title': {
+                    'text': 'Number of participants'
+                }
+            },
+            'series': [
+                {
+                    'name': '-50y',
+                    'data': [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 2, 0, 0, 0, 0]
+                }, {
+                    'name': '50-59y',
+                    'data': [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 2, 0, 2, 0]
+                }
+            ]
+        }
+    ]
+    if add_null:
+        out[0]['xAxis']['categories'].append('No data')
+        out[0]['series'][0]['data'].append(1)
+        out[1]['xAxis']['categories'].append('No data')
+        out[1]['series'][0]['data'].append(1)
+        out[1]['series'][1]['data'].append(0)
+    return out
 
 
 @mock.patch('histograms.io_helper.get_results')
@@ -257,7 +263,7 @@ def test_aggregate_histograms(mock_save_results, mock_get_results):
 
     aggregate_histograms(['1', '2'])
     results = json.loads(mock_save_results.call_args[0][0])
-    assert results == OUTPUT_AGGREGATE
+    assert results == get_output_aggregate(add_null=INCLUDE_NO_DATA)
 
 
 def test_compute_categories_empty():
@@ -312,6 +318,18 @@ def test_main_categories_empty(mock_save_results, mock_get_results, mock_fetch_d
 
 
 def test_align_categories():
+    ha = {
+        'xAxis': {'categories': []},
+        'series': [{'data': []}]
+    }
+    hb = {
+        'xAxis': {'categories': ['1-2', '3-4']},
+        'series': [{'data': [2, 3]}]
+    }
+    ha, hb = _align_categories(ha, hb)
+    assert ha == {'series': [{'data': [0, 0]}], 'xAxis': {'categories': ['1-2', '3-4']}}
+    assert hb == {'xAxis': {'categories': ['1-2', '3-4']}, 'series': [{'data': [2, 3]}]}
+
     ha = {
         'xAxis': {'categories': ['No data']},
         'series': [{'data': [1]}]


### PR DESCRIPTION
Adds flag `INCLUDE_NO_DATA` that controls whether `No data` column in histogram should be displayed. It is False by default, but could be later taken from ENV variables for instance.