### PR TITLE
Logistic regression

### DIFF
--- a/python-knn/tests/unit/test_knn.py
+++ b/python-knn/tests/unit/test_knn.py
@@ -20,8 +20,9 @@ def test_compute_regression(mock_save_results, mock_get_results, mock_fetch_data
     # make some prediction with PFA
     from titus.genpy import PFAEngine
     engine, = PFAEngine.fromJson(pfa_dict)
-    engine.action({'stress_before_test1': 10., 'iq': 10., 'subjectageyears': 70})
-    # TODO: test the prediction
+    # try prediction (PFA correctness is tested in sklearn_to_pfa)
+    pred = engine.action({'stress_before_test1': 10., 'iq': 10., 'subjectageyears': 70})
+    assert round(pred) == 1102
 
 
 @mock.patch('knn.io_helper.fetch_data')
@@ -40,8 +41,9 @@ def test_compute_classification(mock_save_results, mock_get_results, mock_fetch_
     # make some prediction with PFA
     from titus.genpy import PFAEngine
     engine, = PFAEngine.fromJson(pfa_dict)
-    engine.action({'stress_before_test1': 10., 'iq': 10., 'subjectageyears': 70})
-    # TODO: test the prediction
+    # try prediction (PFA correctness is tested in sklearn_to_pfa)
+    pred = engine.action({'stress_before_test1': 10., 'iq': 10., 'subjectageyears': 70})
+    assert pred == 'AD'
 
 
 @mock.patch('knn.io_helper.fetch_data')

--- a/python-linear-regression/README.md
+++ b/python-linear-regression/README.md
@@ -4,6 +4,8 @@
 
 # Python linear-regression
 
+## Continuous target
+
 Python implementation of multivariate linear regression. It supports both nominal and categorical variables and implicitly
 drop null values in data. Both single-node and distributed mode return JSON with structure such as
 ```
@@ -21,6 +23,35 @@ drop null values in data. Both single-node and distributed mode return JSON with
         't_values': 23.0859342033
     },
     ...
+}
+```
+
+## Categorical target
+
+[Multinominal logistic regression](https://en.wikipedia.org/wiki/Multinomial_logistic_regression) implemented as a
+[log-linear model](https://en.wikipedia.org/wiki/Multinomial_logistic_regression#As_a_log-linear_model) by fitting
+logistic regressions on one class versus the others. Only single-node mode is supported, for distributed mode use SGD
+regression.
+
+The output is JSON where each category has its own coefficients
+```
+{
+  'AD': {
+    'agegroup_50-59y': {
+        'coef': 3.2571304466,
+        'p_values': 0.7387901953,
+        'std_err': 9.5993224941,
+        't_values': 0.3393083677
+    },
+    'intercept': {
+        'coef': 1042.2837545842,
+        'p_values': 0.0,
+        'std_err': 45.1479998776,
+        't_values': 23.0859342033
+    },
+    ...
+  },
+  'CN': ...
 }
 ```
 

--- a/python-linear-regression/tests/docker-compose.yml
+++ b/python-linear-regression/tests/docker-compose.yml
@@ -79,7 +79,7 @@ services:
       OUT_HOST: db
       OUT_PORT: 5432
       OUT_DATABASE: woken
-      PARAM_variables: "lefthippocampus"
+      PARAM_variables: "adnicategory"
       PARAM_covariables: "minimentalstate,opticchiasm,subjectageyears"
       PARAM_grouping: ""
       PARAM_meta: "{\"lefthippocampus\":{\"code\":\"lefthippocampus\",\"type\":\"real\",\"mean\":3.0,\"std\":0.35,\"minValue\":0.1,\"maxValue\":5.0},\"minimentalstate\":{\"code\":\"minimentalstate\",\"type\":\"real\",\"mean\":24.0,\"std\":5.0},\"opticchiasm\":{\"code\":\"opticchiasm\",\"type\":\"real\",\"mean\":0.08,\"std\":0.009},\"subjectage\":{\"code\":\"subjectage\",\"type\":\"real\",\"mean\":71.0,\"std\":8.0}, \"rs17125944_c\": {\"code\": \"rs17125944_c\",\"enumerations\": [{\"code\": 0,\"label\": 0},{\"code\": 1,\"label\": 1},{\"code\": 2,\"label\": 2}],\"sql_type\": \"int\",\"type\": \"polynominal\"}, \"adnicategory\": {\"code\": \"adnicategory\", \"enumerations\": [{\"code\": \"AD\", \"label\": \"Alzheimer's Disease\"}, {\"code\": \"MCI\", \"label\": \"Mild Cognitive Impairment\"}, {\"code\": \"CN\", \"label\": \"Cognitively Normal\"}], \"type\": \"polynominal\"}, \"alzheimerbroadcategory\": {\"code\": \"alzheimerbroadcategory\", \"enumerations\": [{\"code\": \"AD\", \"label\": \"Alzheimer's disease\"}, {\"code\": \"CN\", \"label\": \"Cognitively Normal\"}, {\"code\": \"Other\", \"label\": \"Other\"}], \"type\": \"polynominal\"}, \"subjectageyears\": {\"code\": \"subjectageyears\", \"label\": \"Age Years\", \"maxValue\": 130, \"minValue\": 0, \"type\": \"integer\"}}"

--- a/python-linear-regression/tests/test.sh
+++ b/python-linear-regression/tests/test.sh
@@ -47,17 +47,17 @@ $DOCKER_COMPOSE run sample_data_db_setup
 $DOCKER_COMPOSE run woken_db_setup
 
 # single-node mode
-# echo
-# echo "Run the linear-regression algorithm..."
-# $DOCKER_COMPOSE run linear-regression compute
+echo
+echo "Run the linear-regression algorithm..."
+$DOCKER_COMPOSE run linear-regression-single compute
 
 # distributed mode
-echo "Run the linear-regression-a..."
-$DOCKER_COMPOSE run linear-regression-a compute --mode intermediate
-echo "Run the linear-regression-b..."
-$DOCKER_COMPOSE run linear-regression-b compute --mode intermediate
-echo "Run the linear-regression-agg..."
-$DOCKER_COMPOSE run linear-regression-agg compute --mode aggregate --job-ids 1 2
+# echo "Run the linear-regression-a..."
+# $DOCKER_COMPOSE run linear-regression-a compute --mode intermediate
+# echo "Run the linear-regression-b..."
+# $DOCKER_COMPOSE run linear-regression-b compute --mode intermediate
+# echo "Run the linear-regression-agg..."
+# $DOCKER_COMPOSE run linear-regression-agg compute --mode aggregate --job-ids 1 2
 
 echo
 # Cleanup

--- a/python-linear-regression/tests/unit/fixtures.py
+++ b/python-linear-regression/tests/unit/fixtures.py
@@ -1,4 +1,4 @@
-def output():
+def output_regression():
     return {
         'agegroup_-50y': {
             'coef': 0.183,
@@ -23,5 +23,88 @@ def output():
             'p_values': 0.275,
             'std_err': 0.003,
             't_values': -2.168
+        }
+    }
+
+
+def output_classification():
+    return {
+        'AD': {
+            'agegroup_-50y': {
+                'coef': -0.248,
+                'p_values': 0.693,
+                'std_err': 0.627,
+                't_values': -0.395
+            },
+            'intercept': {
+                'coef': 0.224,
+                'p_values': 0.941,
+                'std_err': 3.007,
+                't_values': 0.074
+            },
+            'minimentalstate': {
+                'coef': 0.028,
+                'p_values': 0.669,
+                'std_err': 0.067,
+                't_values': 0.427
+            },
+            'subjectage': {
+                'coef': -0.023,
+                'p_values': 0.56,
+                'std_err': 0.039,
+                't_values': -0.582
+            }
+        },
+        'CN': {
+            'agegroup_-50y': {
+                'coef': 0.894,
+                'p_values': 0.159,
+                'std_err': 0.635,
+                't_values': 1.408
+            },
+            'intercept': {
+                'coef': 0.666,
+                'p_values': 0.822,
+                'std_err': 2.955,
+                't_values': 0.226
+            },
+            'minimentalstate': {
+                'coef': 0.034,
+                'p_values': 0.601,
+                'std_err': 0.065,
+                't_values': 0.523
+            },
+            'subjectage': {
+                'coef': -0.037,
+                'p_values': 0.342,
+                'std_err': 0.039,
+                't_values': -0.95
+            }
+        },
+        'Other': {
+            'agegroup_-50y': {
+                'coef': -0.65,
+                'p_values': 0.296,
+                'std_err': 0.623,
+                't_values': -1.044
+            },
+            'intercept': {
+                'coef': -3.055,
+                'p_values': 0.3,
+                'std_err': 2.946,
+                't_values': -1.037
+            },
+            'minimentalstate': {
+                'coef': -0.066,
+                'p_values': 0.33,
+                'std_err': 0.068,
+                't_values': -0.974
+            },
+            'subjectage': {
+                'coef': 0.061,
+                'p_values': 0.135,
+                'std_err': 0.041,
+                't_values': 1.494
+            }
         }
     }

--- a/python-linear-regression/tests/unit/test_linear_regression.py
+++ b/python-linear-regression/tests/unit/test_linear_regression.py
@@ -12,7 +12,30 @@ def test_main(mock_save_results, mock_fetch_data):
     main()
     output = json.loads(mock_save_results.call_args[0][0])
 
-    assert t.round_dict(fx.output()) == t.round_dict(output)
+    assert t.round_dict(fx.output_regression()) == t.round_dict(output)
+
+
+@mock.patch('linear_regression.io_helper.fetch_data')
+@mock.patch('linear_regression.io_helper.save_results')
+def test_main_logistic(mock_save_results, mock_fetch_data):
+    mock_fetch_data.return_value = t.inputs_classification(limit_to=50, include_nominal=True)
+    main()
+    output = json.loads(mock_save_results.call_args[0][0])
+
+    assert t.round_dict(fx.output_classification()) == t.round_dict(output)
+
+
+@mock.patch('linear_regression.io_helper.fetch_data')
+@mock.patch('linear_regression.io_helper.save_error')
+@mock.patch('sys.exit')
+def test_main_logistic_single_category(mock_exit, mock_save_error, mock_fetch_data):
+    data = t.inputs_classification(limit_to=5, include_nominal=True)
+    # single output
+    data['data']['dependent'][0]['series'] = len(data['data']['dependent'][0]['series']) * ['AD']
+
+    mock_fetch_data.return_value = data
+    main()
+    assert mock_save_error.call_args[0] == ('Not enough data to apply logistic regression.',)
 
 
 @mock.patch('linear_regression.io_helper.fetch_data')

--- a/python-sgd-regression/tests/unit/test_sgd_regression.py
+++ b/python-sgd-regression/tests/unit/test_sgd_regression.py
@@ -95,6 +95,42 @@ def test_main_classification(mock_parameters, mock_save_results, mock_get_result
 
 @pytest.mark.parametrize(
     "method,name", [
+        ("linear_model", "SGDClassifier"),
+        ("neural_network", "MLPClassifier"),
+        # ("gradient_boosting", "GradientBoostingClassifier"),
+        ('naive_bayes', 'MixedNB')
+    ]
+)
+@mock.patch('sgd_regression.io_helper.fetch_data')
+@mock.patch('sgd_regression.io_helper.get_results')
+@mock.patch('sgd_regression.io_helper.save_results')
+@mock.patch('sgd_regression.parameters.fetch_parameters')
+def test_main_classification_single_class(mock_parameters, mock_save_results, mock_get_results, mock_fetch_data, method, name):
+    # create mock objects from database
+    mock_parameters.return_value = {'type': method}
+    data = fx.inputs_classification(include_categorical=True)
+    data['data']['dependent'][0]['series'] = len(data['data']['dependent'][0]['series']) * ['AD']
+    mock_fetch_data.return_value = data
+    mock_get_results.return_value = None
+
+    main(job_id=None, generate_pfa=True)
+
+    pfa = mock_save_results.call_args[0][0]
+    pfa_dict = json.loads(pfa)
+
+    # NOTE: this does not work due to bug in jsonpickle
+    # deserialize model
+    # estimator = deserialize_sklearn_estimator(pfa_dict['metadata']['estimator'])
+    # assert estimator.__class__.__name__ == name
+
+    # make some prediction with PFA
+    from titus.genpy import PFAEngine
+    engine, = PFAEngine.fromJson(pfa_dict)
+    engine.action({'stress_before_test1': 10., 'iq': 10., 'agegroup': '50-59y'})
+
+
+@pytest.mark.parametrize(
+    "method,name", [
         ("linear_model", "SGDClassifier"), ("neural_network", "MLPClassifier"),
         ("gradient_boosting", "GradientBoostingClassifier"), ('naive_bayes', 'MixedNB')
     ]


### PR DESCRIPTION
Adds multinomial logistic regression to `python-linear-regression` image that can handle categorical targets. It **only supports single-node** mode.

Also since multinomial logistic regression uses as many regression as there are categories, its output format has changed to 
```
{[category]: {[covariable]: {coef: ..., p_values: ....}}}
```
for example
```
{
        'AD': {
            'agegroup_-50y': {
                'coef': -0.248,
                'p_values': 0.693,
                'std_err': 0.627,
                't_values': -0.395
            },
            'intercept': {
                'coef': 0.224,
                'p_values': 0.941,
                'std_err': 3.007,
                't_values': 0.074
            },
        },
        'CN': {
            'agegroup_-50y': {
                'coef': 0.894,
                'p_values': 0.159,
                'std_err': 0.635,
                't_values': 1.408
            },
            'intercept': {
                'coef': 0.666,
                'p_values': 0.822,
                'std_err': 2.955,
                't_values': 0.226
            },
...
```
so **frontend would have to handle it differently**. When it gets sorted in frontend, I'll remove WIP and we can merge.