### PR TITLE
Distributed PCA

### DIFF
--- a/python-correlation-heatmap/Dockerfile.pca
+++ b/python-correlation-heatmap/Dockerfile.pca
@@ -1,0 +1,22 @@
+## Build target image
+
+FROM hbpmip/python-correlation-heatmap
+
+ENV DOCKER_IMAGE=hbpmip/python-distributed-pca:0.0.1 \
+    FUNCTION=python-distributed-pca \
+    MODEL_PARAM_graph=pca
+
+ENTRYPOINT ["python", "/src/correlation_heatmap.py"]
+
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name="hbpmip/python-distributed-pca" \
+      org.label-schema.description="Python implementation of distributed PCA" \
+      org.label-schema.url="https://github.com/LREN-CHUV/algorithm-repository" \
+      org.label-schema.vcs-type="git" \
+      org.label-schema.vcs-url="https://github.com/LREN-CHUV/algorithm-repository.git" \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.version="$VERSION" \
+      org.label-schema.vendor="LREN CHUV" \
+      org.label-schema.license="AGPLv3" \
+      org.label-schema.docker.dockerfile="Dockerfile" \
+      org.label-schema.schema-version="1.0"

--- a/python-correlation-heatmap/captain.yml
+++ b/python-correlation-heatmap/captain.yml
@@ -7,3 +7,13 @@ target_image:
     - echo "Finished python-correlation-heatmap"
   test:
     - ./tests/test.sh
+
+pca_image:
+  build: Dockerfile.pca
+  image: hbpmip/python-distributed-pca
+  pre:
+    - echo "Preparing python-distributed-pca"
+  post:
+    - echo "Finished python-distributed-pca"
+  test:
+    - ./tests/test_pca.sh

--- a/python-correlation-heatmap/correlation_heatmap.py
+++ b/python-correlation-heatmap/correlation_heatmap.py
@@ -14,12 +14,13 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from mip_helper import io_helper, shapes, utils, errors
+from mip_helper import io_helper, shapes, utils, errors, parameters
 
 import argparse
 import logging
 from pandas.io import json
 import plotly.graph_objs as go
+from plotly import tools
 import numpy as np
 
 # Configure logging
@@ -27,15 +28,26 @@ logging.basicConfig(level=logging.INFO)
 
 
 @utils.catch_user_error
-def compute():
+def compute(graph_type=None):
     """Perform both intermediate step and aggregation at once."""
     # Read inputs
     logging.info("Fetching data...")
     inputs = io_helper.fetch_data()
+    dep_var = inputs["data"]["dependent"][0]
+    indep_vars = inputs["data"]["independent"]
 
     result = _compute_intermediate_result(inputs)
     corr, columns = _aggregate_results([result])
-    _save_corr_heatmap(corr, columns)
+
+    graph_type = graph_type or parameters.get_parameter('graph', str, 'correlation_heatmap')
+
+    if graph_type == 'correlation_heatmap':
+        _save_corr_heatmap(corr, columns)
+    elif graph_type == 'pca':
+        X = io_helper.fetch_dataframe([dep_var] + indep_vars)
+        _save_pca(corr, columns, X)
+    else:
+        raise errors.UserError('MODEL_PARAM_graph only supports values `correlation_heatmap` and `pca`')
 
 
 @utils.catch_user_error
@@ -58,7 +70,11 @@ def _compute_intermediate_result(inputs):
     variables = []
     for var in [dep_var] + indep_vars:
         if utils.is_nominal(var):
-            logging.warning('Correlation heatmap works only with numerical types ({} is {})'.format(var['name'], var['type']['name']))
+            logging.warning(
+                'Correlation heatmap works only with numerical types ({} is {})'.format(
+                    var['name'], var['type']['name']
+                )
+            )
         else:
             variables.append(var)
 
@@ -101,7 +117,14 @@ def aggregate_stats(job_ids):
 
     corr, columns = _aggregate_results(results)
 
-    _save_corr_heatmap(corr, columns)
+    graph_type = parameters.get_parameter('MODEL_PARAM_graph', str, 'correlation_heatmap')
+
+    if graph_type == 'correlation_heatmap':
+        _save_corr_heatmap(corr, columns)
+    elif graph_type == 'pca':
+        raise errors.UserError('MODEL_PARAM_graph=pca is not yet supported for distributed mode.')
+    else:
+        raise errors.UserError('MODEL_PARAM_graph only supports values `correlation_heatmap` and `pca`')
 
 
 def _aggregate_results(results):
@@ -131,17 +154,176 @@ def _aggregate_results(results):
 def _save_corr_heatmap(corr, columns):
     """Generate heatmap from correlation matrix and return it in plotly format"""
     # revert y-axis so that diagonal goes from top left to bottom right
-    trace = go.Heatmap(z=corr[::-1, :],
-                       x=columns,
-                       y=columns[::-1],
-                       zmin=-1,
-                       zmax=1,
-                       )
+    trace = go.Heatmap(
+        z=corr[::-1, :],
+        x=columns,
+        y=columns[::-1],
+        zmin=-1,
+        zmax=1,
+    )
     data = [trace]
 
     logging.info("Results:\n{}".format(data))
     io_helper.save_results(json.dumps(data), shapes.Shapes.PLOTLY)
     logging.info("DONE")
+
+
+def _pca(corr, X):
+    # calculate eigenvectors and eigenvalues
+    eig_vals, eig_vecs = np.linalg.eig(corr)
+
+    # order eigenvectors and eigenvalues by eigenvectors
+    eig_pairs = [(eig_vals[i], eig_vecs[:, i]) for i in range(len(eig_vals))]
+    eig_pairs = sorted(eig_pairs, key=lambda val_pair: -abs(val_pair[0]))
+    eig_vals, eig_vecs = zip(*eig_pairs)
+    eig_vecs = np.vstack(eig_vecs).T
+
+    logging.info('Eigenvectors:\n{}'.format(eig_vecs))
+    logging.info('\nEigenvalues:\n{}'.format(eig_vals))
+
+    # projection matrix with 2 components
+    W = eig_vecs[:, :2]
+    logging.info('\Projection matrix W:\n{}'.format(W))
+
+    # convert original data to scores
+    # NOTE: since we are working with correlation matrix, original data must be standardized first!
+    X_std = (X - X.mean()) / X.std()
+    Y = X_std.dot(W)
+
+    return eig_vals, eig_vecs, Y
+
+
+def _figure(eig_vals, eig_vecs, Y, X):
+    # plotting
+    fig = tools.make_subplots(
+        rows=2, cols=2, subplot_titles=('Samples scores', 'Variables scores', 'Scree plot', 'Eigen-components')
+    )
+
+    for d in _biplot_samples(Y.values):
+        fig.append_trace(d, 1, 1)
+
+    for d in _biplot_variables(eig_vecs, list(X.columns)):
+        fig.append_trace(d, 1, 2)
+
+    for d in _screeplot(eig_vals):
+        fig.append_trace(d, 2, 1)
+
+    for d in _eigencomponents(eig_vecs, list(X.columns)):
+        fig.append_trace(d, 2, 2)
+
+    var_exp = _explained_variance(eig_vals)
+
+    fig['layout']['xaxis1'].update(title='PC1 ({:.1%})'.format(var_exp[0]))
+    fig['layout']['yaxis1'].update(title='PC2 ({:.1%})'.format(var_exp[1]))
+    fig['layout']['xaxis2'].update(title='PC1 ({:.1%})'.format(var_exp[0]), range=[-1.05, 1.05])
+    fig['layout']['yaxis2'].update(title='PC2 ({:.1%})'.format(var_exp[1]), range=[-1.05, 1.05])
+    fig['layout']['yaxis3'].update(title='Explained variance in percent')
+
+    # unit-circle for biplot
+    circle = {
+        'type': 'circle',
+        'xref': 'x2',
+        'yref': 'y2',
+        'x0': -1,
+        'y0': -1,
+        'x1': 1,
+        'y1': 1,
+        'line': {
+            'color': 'red',
+        },
+    }
+
+    fig['layout'].update(height=800, width=800, title='Principal Component Analysis', shapes=[circle])
+
+    return fig
+
+
+def _save_pca(corr, columns, X):
+    """Generate PCA visualization in plotly format. Inspired by https://plot.ly/ipython-notebooks/principal-component-analysis/"""
+    eig_vals, eig_vecs, Y = _pca(corr, X)
+    fig = _figure(eig_vals, eig_vecs, Y, X)
+
+    logging.info("Results:\n{}".format(fig))
+    io_helper.save_results(json.dumps(fig), shapes.Shapes.PLOTLY)
+    logging.info("DONE")
+
+
+def _screeplot(eig_vals, max_components=5):
+    """Explained variance by principal components.
+    See https://plot.ly/ipython-notebooks/principal-component-analysis/#2--selecting-principal-components
+    """
+    var_exp = _explained_variance(eig_vals) * 100
+    cum_var_exp = np.cumsum(var_exp)
+
+    x = ['PC {}'.format(i) for i in range(1, max_components + 1)]
+
+    trace1 = go.Bar(
+        x=x,
+        y=var_exp,
+        showlegend=False,
+        name='explained variance',
+    )
+
+    trace2 = go.Scatter(
+        x=x,
+        y=cum_var_exp,
+        showlegend=False,
+        name='cumulative explained variance',
+    )
+
+    return go.Data([trace1, trace2])
+
+
+def _biplot_samples(Y):
+    traces = [
+        go.Scatter(
+            x=Y[:, 0],
+            y=Y[:, 1],
+            mode='markers',
+            marker=go.Marker(size=12, line=go.Line(color='rgba(217, 217, 217, 0.14)', width=0.5), opacity=0.6),
+            showlegend=False,
+        )
+    ]
+    return go.Data(traces)
+
+
+def _biplot_variables(eig_vecs, variable_names):
+    traces = []
+
+    for k in range(len(variable_names)):
+        traces.append(
+            go.Scatter(
+                x=[0, eig_vecs[k, 0]],  # first component
+                y=[0, eig_vecs[k, 1]],  # second component
+                mode='lines+markers+text',
+                marker={'color': 'black'},
+                text=[None, variable_names[k]],
+                # textposition='bottom',
+                showlegend=False,
+            )
+        )
+    return go.Data(traces)
+
+
+def _eigencomponents(W, variable_names):
+    # show first two principal components and all their loadings as a bar graph
+    trace1 = go.Bar(
+        x=variable_names,
+        y=W[:, 0],
+        showlegend=False,
+        name='PC1',
+    )
+    trace2 = go.Bar(
+        x=variable_names,
+        y=W[:, 1],
+        showlegend=False,
+        name='PC2',
+    )
+    return go.Data([trace1, trace2])
+
+
+def _explained_variance(eig_vals):
+    return eig_vals / np.sum(eig_vals)
 
 
 if __name__ == '__main__':

--- a/python-correlation-heatmap/tests/docker-compose.yml
+++ b/python-correlation-heatmap/tests/docker-compose.yml
@@ -86,6 +86,7 @@ services:
       PARAM_query: "SELECT lefthippocampus, minimentalstate, opticchiasm, subjectageyears FROM cde_features_a LIMIT 100"
       PARAM_meta: "{\"lefthippocampus\":{\"code\":\"lefthippocampus\",\"type\":\"real\",\"mean\":3.0,\"std\":0.35},\"minimentalstate\":{\"code\":\"minimentalstate\",\"type\":\"real\",\"mean\":24.0,\"std\":5.0},\"opticchiasm\":{\"code\":\"opticchiasm\",\"type\":\"real\",\"mean\":0.08,\"std\":0.009},\"subjectage\":{\"code\":\"subjectage\",\"type\":\"real\",\"mean\":71.0,\"std\":8.0},\"subjectageyears\":{\"description\":\"Subject age in years.\",\"methodology\":\"mip-cde\",\"label\":\"Age Years\",\"minValue\":0,\"code\":\"subjectageyears\",\"units\":\"years\",\"length\":3,\"maxValue\":130.0,\"type\":\"integer\"}}"
       MODEL_PARAM_design: "factorial"
+      MODEL_PARAM_graph: "correlation_heatmap"
 
   correlation-heatmap-a:
     extends: correlation-heatmap-base
@@ -110,5 +111,34 @@ services:
     container_name: "correlation-heatmap-agg"
     environment:
       JOB_ID: '3'
+    links:
+      - "db:db"
+
+  distributed-pca:
+    image: "hbpmip/python-distributed-pca:latest"
+    container_name: "distributed-pca"
+    restart: "no"
+    environment:
+      NODE: job_test
+      JOB_ID: 1
+      IN_DBAPI_DRIVER: postgresql
+      IN_USER: features
+      IN_PASSWORD: featurespwd
+      IN_HOST: db
+      IN_PORT: 5432
+      IN_DATABASE: features
+      OUT_DBAPI_DRIVER: postgresql
+      OUT_USER: woken
+      OUT_PASSWORD: wokenpwd
+      OUT_HOST: db
+      OUT_PORT: 5432
+      OUT_DATABASE: woken
+      PARAM_variables: "lefthippocampus"
+      PARAM_covariables: "minimentalstate,opticchiasm,subjectageyears"
+      PARAM_grouping: ""
+      PARAM_query: "SELECT lefthippocampus, minimentalstate, opticchiasm, subjectageyears FROM cde_features_a LIMIT 100"
+      PARAM_meta: "{\"lefthippocampus\":{\"code\":\"lefthippocampus\",\"type\":\"real\",\"mean\":3.0,\"std\":0.35},\"minimentalstate\":{\"code\":\"minimentalstate\",\"type\":\"real\",\"mean\":24.0,\"std\":5.0},\"opticchiasm\":{\"code\":\"opticchiasm\",\"type\":\"real\",\"mean\":0.08,\"std\":0.009},\"subjectage\":{\"code\":\"subjectage\",\"type\":\"real\",\"mean\":71.0,\"std\":8.0},\"subjectageyears\":{\"description\":\"Subject age in years.\",\"methodology\":\"mip-cde\",\"label\":\"Age Years\",\"minValue\":0,\"code\":\"subjectageyears\",\"units\":\"years\",\"length\":3,\"maxValue\":130.0,\"type\":\"integer\"}}"
+      MODEL_PARAM_design: "factorial"
+      MODEL_PARAM_graph: "pca"
     links:
       - "db:db"

--- a/python-correlation-heatmap/tests/test.sh
+++ b/python-correlation-heatmap/tests/test.sh
@@ -47,12 +47,16 @@ $DOCKER_COMPOSE run sample_data_db_setup
 $DOCKER_COMPOSE run woken_db_setup
 
 echo
-echo "Run the correlation-heatmap-a..."
-$DOCKER_COMPOSE run correlation-heatmap-a compute --mode intermediate
-echo "Run the correlation-heatmap-b..."
-$DOCKER_COMPOSE run correlation-heatmap-b compute --mode intermediate
-echo "Run the correlation-heatmap-agg..."
-$DOCKER_COMPOSE run correlation-heatmap-agg compute --mode aggregate --job-ids 1 2
+echo "Run the distributed-pca algorithm..."
+$DOCKER_COMPOSE run distributed-pca compute
+
+# echo
+# echo "Run the correlation-heatmap-a..."
+# $DOCKER_COMPOSE run correlation-heatmap-a compute --mode intermediate
+# echo "Run the correlation-heatmap-b..."
+# $DOCKER_COMPOSE run correlation-heatmap-b compute --mode intermediate
+# echo "Run the correlation-heatmap-agg..."
+# $DOCKER_COMPOSE run correlation-heatmap-agg compute --mode aggregate --job-ids 1 2
 
 echo
 # Cleanup

--- a/python-correlation-heatmap/tests/unit/test_correlation_heatmap.py
+++ b/python-correlation-heatmap/tests/unit/test_correlation_heatmap.py
@@ -30,10 +30,10 @@ def round_dict(d, precision=3):
 
 @mock.patch('correlation_heatmap.io_helper.fetch_data')
 @mock.patch('correlation_heatmap.io_helper.save_results')
-def test_compute(mock_save_results, mock_fetch_data):
+def test_compute_heatmap(mock_save_results, mock_fetch_data):
     mock_fetch_data.return_value = fx.inputs_regression(include_categorical=False)
 
-    compute()
+    compute('correlation_heatmap')
     results = json.loads(mock_save_results.call_args[0][0])
     assert round_dict(results) == [
         {
@@ -45,6 +45,16 @@ def test_compute(mock_save_results, mock_fetch_data):
             'zmax': 1
         }
     ]
+
+
+@mock.patch('correlation_heatmap.io_helper.fetch_data')
+@mock.patch('correlation_heatmap.io_helper.save_results')
+def test_compute_pca(mock_save_results, mock_fetch_data):
+    mock_fetch_data.return_value = fx.inputs_regression(include_categorical=False)
+
+    compute('pca')
+    results = json.loads(mock_save_results.call_args[0][0])
+    assert set(results.keys()) == {'layout', 'data'}
 
 
 @mock.patch('correlation_heatmap.io_helper.fetch_data')


### PR DESCRIPTION
Adds `MODEL_PARAM_graph` parameter with two modes `pca` and `correlation_heatmap`, both returning Plotly graph.

PCA only works in single-node mode yet. Generalization to distributed mode is straightforward, but low priority at the moment.